### PR TITLE
Images automatically show in notebooks

### DIFF
--- a/fastai/imports/core.py
+++ b/fastai/imports/core.py
@@ -1,4 +1,4 @@
-import csv, gc, gzip, os, pickle, shutil, sys, warnings
+import csv, gc, gzip, os, pickle, shutil, sys, warnings, io
 import abc, collections, hashlib, itertools, operator
 import math, matplotlib.pyplot as plt, numpy as np, pandas as pd, random
 import scipy.stats, scipy.special

--- a/fastai/vision/image.py
+++ b/fastai/vision/image.py
@@ -73,6 +73,7 @@ class Image(ImageBase):
     def device(self)->torch.device: return self._px.device
 
     def __repr__(self): return f'{self.__class__.__name__} ({self.shape})'
+    def _repr_jpeg_(self): return self._image2bytestr()
 
     def refresh(self)->None:
         "Applies any logit or affine transfers that have been "


### PR DESCRIPTION
Very ugly way to show an image inside jupyter notebook.

The alternative is
`def __repr__(self): 
        self.show()
        return f'{self.__class__.__name__} ({self.shape})'`
