### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For other setups/platforms use `pip install` at the moment (see above).
 ### Developer Install
 
     conda install pytorch-nightly -c pytorch
-    conda install torchvision -c pytorch
+    pip install torchvision
     git clone https://github.com/fastai/fastai_pytorch
     cd fastai_pytorch
     pip install -e .


### PR DESCRIPTION
conda install torchvision -c pytorch -> Installs torch 0.4.1 when we get torchvision package. 
We could use  pip install torchvision to avoid conflicts.

Find Below 
python                    3.7.0                hc3d631a_0
pytorch                   0.4.1           py37_py36_py35_py27__9.0.176_7.1.2_2    pytorch
pytorch-nightly           1.0.0.dev20180927     py3.7_cpu_0    pytorch
readline                  7.0                  h7b6447c_5
setuptools                40.2.0                   py37_0
six                       1.11.0                   py37_1
sqlite                    3.25.2               h7b6447c_0
tk                        8.6.8                hbc83047_0
torchvision               0.2.1                    py37_1    pytorch